### PR TITLE
AppVeyor: Test on Python 3.8, 3.9, 3.10, 3.11, and 3.12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,36 +1,32 @@
-# What Python version is installed where:
-# https://www.appveyor.com/docs/build-environment/#python
+# appveyor.yml - https://www.appveyor.com/docs/lang/python
+# https://www.appveyor.com/docs/windows-images-software/#visual-studio-2022
+---
+image: Visual Studio 2022
 
 environment:
-  matrix:
-    - PYTHON: "C:\\Python35"
-      TOX_ENV: "py35"
-
-    - PYTHON: "C:\\Python36"
-      TOX_ENV: "py36"
-
-    - PYTHON: "C:\\Python37"
-      TOX_ENV: "py37"
-
-    - PYTHON: "C:\\Python38"
-      TOX_ENV: "py38"
+  matrix:AppVeyor: Test on Python 3.8, 3.9, 3.10, 3.11, 3.12
+    - TOXENV: py38    # https://devguide.python.org/versions
+    - TOXENV: py39
+    - TOXENV: py310
+    - TOXENV: py311
+    - TOXENV: py312
 
 init:
-  - "%PYTHON%/python -V"
-  - "%PYTHON%/python -c \"import struct;print( 8 * struct.calcsize(\'P\'))\""
+  - py -VV
+  - py -c "import struct;print( 8 * struct.calcsize(\'P\'))"
+  - py --list  # What Python versions are installed?
 
 install:
-  - "%PYTHON%/Scripts/easy_install -U pip"
-  - "%PYTHON%/Scripts/pip install tox"
-  - "%PYTHON%/Scripts/pip install wheel"
+  - py -m pip install --upgrade pip
+  - py -m pip install build tox wheel
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - "%PYTHON%/Scripts/tox -e %TOX_ENV%"
+  - py -m tox
 
 after_test:
-  - "%PYTHON%/python setup.py bdist_wheel"
+  - py -m build
   - ps: "ls dist"
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,12 +11,10 @@ environment:
     - TOXENV: py311
     - TOXENV: py312
 
-init:
-  - py -VV
-  - py -c "import struct;print( 8 * struct.calcsize(\'P\'))"
-  - py --list  # What Python versions are installed?
-
 install:
+  - py -VV
+  - py -c "import struct ; print( 8 * struct.calcsize('P'))"
+  - py --list  # What Python versions are installed?
   - py -m pip install --upgrade pip
   - py -m pip install build tox wheel
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 image: Visual Studio 2022
 
 environment:
-  matrix:AppVeyor: Test on Python 3.8, 3.9, 3.10, 3.11, 3.12
+  matrix:
     - TOXENV: py38    # https://devguide.python.org/versions
     - TOXENV: py39
     - TOXENV: py310


### PR DESCRIPTION
https://devguide.python.org/versions

https://ci.appveyor.com/project/daninge98/pytest-expect-test/history is not running on pull requests.